### PR TITLE
Add ftcolor.c

### DIFF
--- a/freetype.lua
+++ b/freetype.lua
@@ -34,6 +34,7 @@ files {
   "src/base/ftadvanc.c",
   "src/base/ftbitmap.c",
   "src/base/ftcalc.c",
+  "src/base/ftcolor.c",
   "src/base/ftdebug.c",
   "src/base/ftfntfmt.c",
   "src/base/ftfstype.c",


### PR DESCRIPTION
Add `src/base/ftcolor.c` in order to get the missing `FT_Palette_Select` function. 