### PR TITLE
Hide symbols so external freetype system libs won't have their symbos use

### DIFF
--- a/include/freetype/config/public-macros.h
+++ b/include/freetype/config/public-macros.h
@@ -74,7 +74,7 @@ FT_BEGIN_HEADER
   /* gcc, clang */
 #elif ( defined( __GNUC__ ) && __GNUC__ >= 4 ) || defined( __clang__ )
 #define FT_PUBLIC_FUNCTION_ATTRIBUTE \
-          __attribute__(( visibility( "default" ) ))
+          __attribute__(( visibility( "hidden" ) ))
 
   /* Sun */
 #elif defined( __SUNPRO_C ) && __SUNPRO_C >= 0x550


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/java/issues/6345

On Linux, the fontconfig system library is used by runtimecore which
has a dependency on the system freetype library. Hide the symbols so
the system's freetype symbols are not used in runtime and the internal
static linkage library is used instead.