### PR TITLE
Build a missing file needed for pdfium

### DIFF
--- a/freetype.lua
+++ b/freetype.lua
@@ -37,6 +37,7 @@ files {
   "src/base/ftfntfmt.c",
   "src/base/ftfstype.c",
   "src/base/ftgloadr.c",
+  "src/base/ftglyph.c",
   "src/base/fthash.c",
   "src/base/ftinit.c",
   "src/base/ftlcdfil.c",


### PR DESCRIPTION
Adds a missing file needed to build a new library. Tested this locally by building every platform, architecture and target